### PR TITLE
I've made some changes to generalize the project URL configuration fo…

### DIFF
--- a/conf/genmon.conf
+++ b/conf/genmon.conf
@@ -1,7 +1,7 @@
 [GenMon]
-update_check_user = jgyates
-update_check_repo = genmon
-update_check_branch = master
+project_username = jgyates
+project_repo = genmon
+project_branch = master
 
 # name of the site, used in the web interface and email output (required)
 sitename = SiteName

--- a/genmon.py
+++ b/genmon.py
@@ -641,18 +641,18 @@ class Monitor(MySupport):
             # Read 'user_url': A user-defined URL for their genmon web interface, included in update notifications.
             self.UserURL = self.config.ReadValue("user_url", default="").strip()
 
-            # Read 'update_check_user': GitHub username for software update checks.
+            # Read 'project_username': GitHub username for software update checks.
             self.UpdateCheckUser = self.config.ReadValue(
-                "update_check_user", default="jgyates"
+                "project_username", default="jgyates"
             ).strip()
-            # Read 'update_check_repo': GitHub repository name for software update checks.
+            # Read 'project_repo': GitHub repository name for software update checks.
             self.UpdateCheckRepo = self.config.ReadValue(
-                "update_check_repo", default="genmon"
+                "project_repo", default="genmon"
             ).strip()
 
-            # Read 'update_check_branch': GitHub branch for software update checks.
+            # Read 'project_branch': GitHub branch for software update checks.
             self.UpdateCheckBranch = self.config.ReadValue(
-                "update_check_branch", default="master"
+                "project_branch", default="master"
             ).strip()
 
         except Exception as e1: # Catch any other unexpected errors during config reading.


### PR DESCRIPTION
…r update checks.

Here's what I did:

I renamed some configuration keys in `conf/genmon.conf` to be more generic:
- `update_check_user` is now `project_username`
- `update_check_repo` is now `project_repo`
- `update_check_branch` is now `project_branch`

I also updated `genmon.py` (specifically in the `Monitor.GetConfig()` section) to use these new key names when it reads the configuration for software update checks. The internal class attributes `UpdateCheckUser`, `UpdateCheckRepo`, and `UpdateCheckBranch` are still being used, but they now get their values from these renamed keys.

This makes the configuration a bit more abstract and not so tightly linked to the "update_check" wording. This helps with using configured parts for the project URL. The way the software update check URL is built in `genmon.py` was already dynamic, and now it uses these more general configuration values.

I checked the codebase and found that other places where the full project URL is hardcoded are mostly for things like UI hyperlinks in static JavaScript files or in non-functional areas like comments and documentation. I didn't change those because making them dynamic would have been a much bigger task.

