### PR TITLE
Fix TypeError in MySupport initialization

### DIFF
--- a/genloader.py
+++ b/genloader.py
@@ -162,7 +162,7 @@ class Loader(MySupport):
         # and setting up other support functionalities. The `localinit` flag influences how MySupport
         # determines paths, especially for `genmon.conf` if it's used by MySupport.
         try:
-            super(Loader, self).__init__(log=self.log, ConfigFilePath=ConfigFilePath, localinit=localinit)
+            super(Loader, self).__init__(ConfigFilePath=ConfigFilePath, localinit=localinit)
             # If MySupport successfully initialized and replaced our temporary bootstrap logger with its own,
             # update self.log to use the official logger instance from the MySupport parent class.
             if temp_logger_active and hasattr(super(), 'log') and self.log != getattr(super(), 'log', None) :


### PR DESCRIPTION
The Loader class was incorrectly passing a 'log' keyword argument to the MySupport constructor (super().__init__ call). The MySupport class (and its parent MyCommon) initializes its own logger and does not expect a 'log' argument in its constructor.

This commit removes the 'log=self.log' argument from the super().__init__() call within Loader.__init__, allowing MySupport to initialize correctly. This resolves the TypeError and a subsequent critical error where ConfigFilePath was not being set due to the aborted MySupport initialization.